### PR TITLE
Fixed header transition effect in desktop mode

### DIFF
--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -27,7 +27,7 @@ export default function Layout({
           scrolled
             ? "border-b border-gray-200 bg-white/50 backdrop-blur-xl"
             : "bg-white/0"
-        } z-30 transition-all`}
+        } z-30 transition-opacity`}
       >
         <div className="mx-5 flex h-16 max-w-screen-xl items-center justify-between xl:mx-auto">
           <Link href="/" className="flex items-center font-display text-2xl">


### PR DESCRIPTION
The transition-all property is making the header fluctuate when scrolling down in desktop mode.
This commit fixes that issue.